### PR TITLE
feat: 프로필 수정 페이지 구현

### DIFF
--- a/src/components/GenderSelectNone.tsx
+++ b/src/components/GenderSelectNone.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import useUserStore from '../store/userStore';
+import styles from './css/GenderSelect.module.css';
+
+const GenderSelectNone: React.FC = () => {
+  const { gender } = useUserStore();
+
+  const handleBlockedClick = () => {
+    alert('성별은 수정할 수 없습니다.');
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      {['남자', '여자'].map((g) => (
+        <button
+          key={g}
+          onClick={handleBlockedClick}
+          className={gender === g ? styles.selected : styles.button}
+        >
+          {g}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default GenderSelectNone;

--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react';
+import BirthSelectNone from '../components/BirthSelectNone';
+import GenderSelectNone from '../components/GenderSelectNone';
+import EmailInputNone from '../components/EmailInputNone';
+import NicknameInput from '../components/NicknameInput';
+import useUserStore from '../store/userStore';
+import styles from './css/RegisterPage.module.css';
+import { useNavigate } from 'react-router-dom';
+import axiosInstance from '../api/axiosInstance';
+import PageHeader from '../components/PageHeader';
+
+const EditProfilePage: React.FC = () => {
+  const navigate = useNavigate();
+  const { nickname, email, gender, birth, setUserInfo } = useUserStore();
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    // 페이지 로드 시 사용자 정보 가져오기
+    const fetchUserProfile = async () => {
+      try {
+        const response = await axiosInstance.get('/api/auth/user/feature');
+        if (response.status === 200) {
+          const userData = response.data.data;
+
+          // 생년월일 파싱
+          const [year, month, day] = userData.birthday.split('-');
+
+          setUserInfo({
+            nickname: userData.username,
+            email: userData.email,
+            gender: userData.gender,
+            birth: { year, month, day },
+          });
+        }
+      } catch (error) {
+        console.error('프로필 정보 로드 실패:', error);
+        alert('프로필 정보를 불러오는데 실패했습니다.');
+      }
+    };
+
+    fetchUserProfile();
+  }, [setUserInfo]);
+
+  const isBirthFilled = birth.year !== '' && birth.month !== '' && birth.day !== '';
+  const isGenderFilled = gender !== '';
+  const isNicknameFilled = nickname.trim() !== '';
+
+  const isFormValid = isBirthFilled && isGenderFilled && isNicknameFilled;
+
+  const handleSubmit = async () => {
+    if (!isFormValid) return;
+
+    setIsLoading(true);
+
+    try {
+      const birthday = `${birth.year}-${birth.month.padStart(2, '0')}-${birth.day.padStart(2, '0')}`;
+
+      const requestBody = {
+        username: nickname,
+        birthday,
+        gender,
+        email,
+      };
+
+      const response = await axiosInstance.patch('/api/auth/user/feature', requestBody);
+
+      if (response.status === 200) {
+        alert('프로필이 성공적으로 수정되었습니다.');
+        navigate('/mypage');
+      } else {
+        alert('수정에 실패했습니다. 다시 시도해주세요.');
+      }
+    } catch (error: any) {
+      console.error('프로필 수정 실패:', error);
+      const errorMessage = error.response?.data?.message || '프로필 수정 중 오류가 발생했습니다.';
+      alert(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <PageHeader title="프로필 수정" />
+      <h1 className={styles.title}>프로필 수정</h1>
+
+      <NicknameInput />
+      <EmailInputNone />
+      <GenderSelectNone />
+      <BirthSelectNone />
+
+      <button
+        className={styles.submitButton}
+        disabled={!isFormValid || isLoading}
+        onClick={handleSubmit}
+      >
+        {isLoading ? '수정 중...' : '수정 완료'}
+      </button>
+    </div>
+  );
+};
+
+export default EditProfilePage;


### PR DESCRIPTION
## Summary
- 사용자 프로필 수정 기능을 구현했습니다
- 이메일, 성별, 생년월일은 수정 불가능하고 닉네임만 수정 가능합니다
- 페이지 로드 시 기존 사용자 정보를 자동으로 불러옵니다

## Changes
### 새로 추가된 파일
- `src/pages/EditProfilePage.tsx` - 프로필 수정 페이지
- `src/components/BirthSelectNone.tsx` - 비활성화된 생년월일 선택 컴포넌트
- `src/components/GenderSelectNone.tsx` - 비활성화된 성별 선택 컴포넌트
- `src/components/EmailInputNone.tsx` - 비활성화된 이메일 입력 컴포넌트
- `src/utils/generateOptions.ts` - 드롭다운 옵션 생성 유틸리티

### 주요 기능
- ✅ GET `/api/auth/user/feature`로 사용자 정보 로드
- ✅ PATCH `/api/auth/user/feature`로 닉네임 수정
- ✅ 이메일, 성별, 생년월일은 읽기 전용으로 표시
- ✅ 폼 유효성 검사 및 에러 처리
- ✅ 로딩 상태 관리 및 사용자 피드백

## Test plan
- [ ] 프로필 수정 페이지 접근 시 기존 정보가 올바르게 표시되는지 확인
- [ ] 닉네임 수정 후 "수정 완료" 버튼 클릭 시 정상적으로 저장되는지 확인
- [ ] 이메일, 성별, 생년월일 필드가 수정 불가능한지 확인
- [ ] 성별 버튼 클릭 시 "성별은 수정할 수 없습니다" 알림이 표시되는지 확인
- [ ] 빈 닉네임 입력 시 버튼이 비활성화되는지 확인
- [ ] API 오류 발생 시 적절한 에러 메시지가 표시되는지 확인
- [ ] 수정 완료 후 마이페이지로 이동하는지 확인