### PR TITLE
Feat/#16auth redirect handler

### DIFF
--- a/src/pages/AuthRedirect.tsx
+++ b/src/pages/AuthRedirect.tsx
@@ -1,0 +1,101 @@
+import { useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+
+const AuthRedirect = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (!code) {
+      alert('인가 코드가 없습니다.');
+      navigate('/');
+      return;
+    }
+
+    const exchangeCodeForToken = async () => {
+      try {
+        const response = await axios.post(
+          `https://13.125.224.67.nip.io/api/token/exchange?code=${code}`,
+          null,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+
+        const { accessToken, refreshToken, role, verifyId } = response.data.data;
+        console.log('User role:', role);
+
+        // 토큰 저장
+        localStorage.setItem('access_token', accessToken);
+        localStorage.setItem('refresh_token', refreshToken);
+        localStorage.setItem('verify_id', verifyId);
+
+        // 역할에 따라 이동
+        if (role === 'ROLE_SEMI_USER') {
+          navigate('/register');
+        } else if (role === 'ROLE_USER') {
+          navigate('/mainpage');
+        } else {
+          alert('알 수 없는 사용자 역할입니다.');
+          navigate('/');
+        }
+      } catch (error: any) {
+        console.error('토큰 교환 실패:', error);
+        const errorMessage =
+          error.response?.data?.message || '로그인 처리 중 오류가 발생했습니다.';
+        alert(errorMessage);
+        navigate('/');
+      }
+    };
+
+    exchangeCodeForToken();
+  }, [searchParams, navigate]);
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.loader}></div>
+      <p style={styles.text}>로그인 처리 중입니다. 잠시만 기다려주세요...</p>
+    </div>
+  );
+};
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    backgroundColor: '#ffffff',
+  },
+  loader: {
+    width: '48px',
+    height: '48px',
+    border: '4px solid #f3f3f3',
+    borderTop: '4px solid #3977F4',
+    borderRadius: '50%',
+    animation: 'spin 1s linear infinite',
+  },
+  text: {
+    marginTop: '20px',
+    fontSize: '16px',
+    fontWeight: 500,
+    color: '#373737',
+  },
+};
+
+// 인라인 스타일에 애니메이션을 추가하기 위해 스타일 시트에 주입
+const styleSheet = document.createElement('style');
+styleSheet.textContent = `
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+`;
+document.head.appendChild(styleSheet);
+
+export default AuthRedirect;


### PR DESCRIPTION
## Related Issue

* Closes #<이슈_번호>

## 📝Description

OAuth 2.0 인증 흐름의 마지막 단계인 리다이렉트 콜백을 처리하는 `AuthRedirect` 컴포넌트를 구현했습니다.
사용자가 소셜 로그인 후 돌아왔을 때, URL의 인가 코드를 사용해 서버로부터 실제 JWT 토큰을 발급받고 저장합니다.

## ✨Key Changes

* **토큰 교환 로직:** `useSearchParams`로 'code'를 가져와 `axios.post`로 토큰 교환을 요청합니다.
* **토큰 저장:** `localStorage`에 `accessToken`, `refreshToken`, `verifyId`를 저장합니다.
* **역할 기반 라우팅:** `useNavigate`를 사용해 응답받은 'role'에 따라 분기합니다.
    * `ROLE_SEMI_USER` -> `/register`
    * `ROLE_USER` -> `/mainpage`
* **UI/UX:** 토큰 교환이 진행되는 동안 로딩 스피너와 안내 문구를 표시합니다.
* **에러 핸들링:** API 요청 실패 또는 'code'가 없을 경우, 사용자에게 알림(alert)을 표시하고 홈으로 리다이렉트합니다.

## Screen Shot (Optional)

[로딩 스피너가 보이는 화면 스크린샷]
[로그인 성공 후 /mainpage로 이동된 화면 스크린샷]

## 💬To Reviewer

* 백엔드 API 엔드포인트(`13.125.224.67.nip.io`)가 현재 개발 환경에 맞게 설정되었는지 확인 부탁드립니다.
* `ROLE_SEMI_USER`와 `ROLE_USER` 외 다른 역할이 추가될 경우의 처리 방안에 대한 논의가 필요할 수 있습니다.